### PR TITLE
Enable links on top navigation bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .vscode/
 .idea/
 _public/
+
+.fake
+.ionide

--- a/config.fsx
+++ b/config.fsx
@@ -40,6 +40,7 @@ let config = {
         {Script = "docs.fsx"; Trigger = Once; OutputFile = NewFileName "docs.html" }
         {Script = "install.fsx"; Trigger = Once; OutputFile = NewFileName "install.html" }
         {Script = "community.fsx"; Trigger = Once; OutputFile = NewFileName "community.html" }
+        {Script = "foundation.fsx"; Trigger = Once; OutputFile = NewFileName "foundation.html" }
         {Script = "contact.fsx"; Trigger = Once; OutputFile = NewFileName "contact.html" }
     ]
 }

--- a/config.fsx
+++ b/config.fsx
@@ -37,6 +37,7 @@ let config = {
         {Script = "staticfile.fsx"; Trigger = OnFilePredicate staticPredicate; OutputFile = SameFileName }
         {Script = "index.fsx"; Trigger = Once; OutputFile = NewFileName "index.html" }
         {Script = "about.fsx"; Trigger = Once; OutputFile = NewFileName "about.html" }
+        {Script = "docs.fsx"; Trigger = Once; OutputFile = NewFileName "docs.html" }
         {Script = "contact.fsx"; Trigger = Once; OutputFile = NewFileName "contact.html" }
     ]
 }

--- a/config.fsx
+++ b/config.fsx
@@ -38,6 +38,7 @@ let config = {
         {Script = "index.fsx"; Trigger = Once; OutputFile = NewFileName "index.html" }
         {Script = "about.fsx"; Trigger = Once; OutputFile = NewFileName "about.html" }
         {Script = "docs.fsx"; Trigger = Once; OutputFile = NewFileName "docs.html" }
+        {Script = "install.fsx"; Trigger = Once; OutputFile = NewFileName "install.html" }
         {Script = "contact.fsx"; Trigger = Once; OutputFile = NewFileName "contact.html" }
     ]
 }

--- a/config.fsx
+++ b/config.fsx
@@ -39,6 +39,7 @@ let config = {
         {Script = "about.fsx"; Trigger = Once; OutputFile = NewFileName "about.html" }
         {Script = "docs.fsx"; Trigger = Once; OutputFile = NewFileName "docs.html" }
         {Script = "install.fsx"; Trigger = Once; OutputFile = NewFileName "install.html" }
+        {Script = "community.fsx"; Trigger = Once; OutputFile = NewFileName "community.html" }
         {Script = "contact.fsx"; Trigger = Once; OutputFile = NewFileName "contact.html" }
     ]
 }

--- a/generators/community.fsx
+++ b/generators/community.fsx
@@ -1,0 +1,40 @@
+#r "../_lib/Fornax.Core.dll"
+#load "layout.fsx"
+
+open Html
+
+let about = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nisi diam, vehicula quis blandit id, suscipit sed libero. Proin at diam dolor. In hac habitasse platea dictumst. Donec quis dui vitae quam eleifend dignissim non sed libero. In hac habitasse platea dictumst. In ullamcorper mollis risus, a vulputate quam accumsan at. Donec sed felis sodales, blandit orci id, vulputate orci."
+
+let generate' (ctx : SiteContents) (_: string) =
+  let siteInfo = ctx.TryGetValue<Globalloader.SiteInfo> ()
+  let desc =
+    siteInfo
+    |> Option.map (fun si -> si.description)
+    |> Option.defaultValue ""
+
+
+  Layout.layout ctx "Home" [
+    section [Class "hero is-info is-medium is-bold"] [
+      div [Class "hero-body"] [
+        div [Class "container has-text-centered"] [
+          h1 [Class "title"] [!!desc]
+        ]
+      ]
+    ]
+    div [Class "container"] [
+      section [Class "articles"] [
+        div [Class "column is-8 is-offset-2"] [
+            div [Class "card article"] [
+                div [Class "card-content"] [
+                    div [Class "content article-body"] [
+                        !! about
+                    ]
+                ]
+            ]
+        ]
+      ]
+    ]]
+
+let generate (ctx : SiteContents) (projectRoot: string) (page: string) =
+  generate' ctx page
+  |> Layout.render ctx

--- a/generators/docs.fsx
+++ b/generators/docs.fsx
@@ -1,0 +1,40 @@
+#r "../_lib/Fornax.Core.dll"
+#load "layout.fsx"
+
+open Html
+
+let about = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nisi diam, vehicula quis blandit id, suscipit sed libero. Proin at diam dolor. In hac habitasse platea dictumst. Donec quis dui vitae quam eleifend dignissim non sed libero. In hac habitasse platea dictumst. In ullamcorper mollis risus, a vulputate quam accumsan at. Donec sed felis sodales, blandit orci id, vulputate orci."
+
+let generate' (ctx : SiteContents) (_: string) =
+  let siteInfo = ctx.TryGetValue<Globalloader.SiteInfo> ()
+  let desc =
+    siteInfo
+    |> Option.map (fun si -> si.description)
+    |> Option.defaultValue ""
+
+
+  Layout.layout ctx "Home" [
+    section [Class "hero is-info is-medium is-bold"] [
+      div [Class "hero-body"] [
+        div [Class "container has-text-centered"] [
+          h1 [Class "title"] [!!desc]
+        ]
+      ]
+    ]
+    div [Class "container"] [
+      section [Class "articles"] [
+        div [Class "column is-8 is-offset-2"] [
+            div [Class "card article"] [
+                div [Class "card-content"] [
+                    div [Class "content article-body"] [
+                        !! about
+                    ]
+                ]
+            ]
+        ]
+      ]
+    ]]
+
+let generate (ctx : SiteContents) (projectRoot: string) (page: string) =
+  generate' ctx page
+  |> Layout.render ctx

--- a/generators/foundation.fsx
+++ b/generators/foundation.fsx
@@ -1,0 +1,40 @@
+#r "../_lib/Fornax.Core.dll"
+#load "layout.fsx"
+
+open Html
+
+let about = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nisi diam, vehicula quis blandit id, suscipit sed libero. Proin at diam dolor. In hac habitasse platea dictumst. Donec quis dui vitae quam eleifend dignissim non sed libero. In hac habitasse platea dictumst. In ullamcorper mollis risus, a vulputate quam accumsan at. Donec sed felis sodales, blandit orci id, vulputate orci."
+
+let generate' (ctx : SiteContents) (_: string) =
+  let siteInfo = ctx.TryGetValue<Globalloader.SiteInfo> ()
+  let desc =
+    siteInfo
+    |> Option.map (fun si -> si.description)
+    |> Option.defaultValue ""
+
+
+  Layout.layout ctx "Home" [
+    section [Class "hero is-info is-medium is-bold"] [
+      div [Class "hero-body"] [
+        div [Class "container has-text-centered"] [
+          h1 [Class "title"] [!!desc]
+        ]
+      ]
+    ]
+    div [Class "container"] [
+      section [Class "articles"] [
+        div [Class "column is-8 is-offset-2"] [
+            div [Class "card article"] [
+                div [Class "card-content"] [
+                    div [Class "content article-body"] [
+                        !! about
+                    ]
+                ]
+            ]
+        ]
+      ]
+    ]]
+
+let generate (ctx : SiteContents) (projectRoot: string) (page: string) =
+  generate' ctx page
+  |> Layout.render ctx

--- a/generators/install.fsx
+++ b/generators/install.fsx
@@ -1,0 +1,40 @@
+#r "../_lib/Fornax.Core.dll"
+#load "layout.fsx"
+
+open Html
+
+let about = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nisi diam, vehicula quis blandit id, suscipit sed libero. Proin at diam dolor. In hac habitasse platea dictumst. Donec quis dui vitae quam eleifend dignissim non sed libero. In hac habitasse platea dictumst. In ullamcorper mollis risus, a vulputate quam accumsan at. Donec sed felis sodales, blandit orci id, vulputate orci."
+
+let generate' (ctx : SiteContents) (_: string) =
+  let siteInfo = ctx.TryGetValue<Globalloader.SiteInfo> ()
+  let desc =
+    siteInfo
+    |> Option.map (fun si -> si.description)
+    |> Option.defaultValue ""
+
+
+  Layout.layout ctx "Home" [
+    section [Class "hero is-info is-medium is-bold"] [
+      div [Class "hero-body"] [
+        div [Class "container has-text-centered"] [
+          h1 [Class "title"] [!!desc]
+        ]
+      ]
+    ]
+    div [Class "container"] [
+      section [Class "articles"] [
+        div [Class "column is-8 is-offset-2"] [
+            div [Class "card article"] [
+                div [Class "card-content"] [
+                    div [Class "content article-body"] [
+                        !! about
+                    ]
+                ]
+            ]
+        ]
+      ]
+    ]]
+
+let generate (ctx : SiteContents) (projectRoot: string) (page: string) =
+  generate' ctx page
+  |> Layout.render ctx

--- a/generators/layout.fsx
+++ b/generators/layout.fsx
@@ -70,9 +70,9 @@ let layout (ctx : SiteContents) active bodyCnt =
                 div [Class "header-main"] [
                   nav [] [
                     ul [] [
-                      li [] [ a [Href "#"] [!! "ABOUT F#"] ]
+                      li [] [ a [Href "about.html"] [!! "ABOUT F#"] ]
                       li [] [
-                        a [Href "#"] [!! "DOCS"]
+                        a [Href "docs.html"] [!! "DOCS"]
                         div [ Class "header-btm" ] [
                           ul [] [
                             li [ Class "connect" ] [ a [Href "#"] [!! "API"] ]
@@ -84,9 +84,9 @@ let layout (ctx : SiteContents) active bodyCnt =
                         ]
                       ]
                       li [] [ a [Href "https://try.fsharp.org"] [!! "TRY ONLINE"] ]
-                      li [] [ a [Href "#"] [!! "INSTALL"] ]
-                      li [] [ a [Href "#"] [!! "COMMUNITY"] ]
-                      li [] [ a [Href "#"] [!! "FOUNDATION"] ]
+                      li [] [ a [Href "install.html"] [!! "INSTALL"] ]
+                      li [] [ a [Href "community.html"] [!! "COMMUNITY"] ]
+                      li [] [ a [Href "foundation.html"] [!! "FOUNDATION"] ]
                     ]
                   ]
                 ]

--- a/loaders/globalloader.fsx
+++ b/loaders/globalloader.fsx
@@ -6,6 +6,6 @@ type SiteInfo = {
 }
 
 let loader (projectRoot: string) (siteContent: SiteContents) =
-    siteContent.Add({title = "F Sharp"; description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"})
+    siteContent.Add({title = "F# Software Foundation"; description = "The Official Website of the F# Software Foundation, whose mission is to grow, support, and educate a diverse community around the F# programming language ecosystem."})
 
     siteContent


### PR DESCRIPTION
This PR enables the following links, which are the ones of the top navigation bar:
- About F#
- Docs
- Install
- Community
- Foundation

Also, for each one of them, a corresponding generator script and an entry in the `Generators` list in `config.fsx` is created.